### PR TITLE
fix metrics

### DIFF
--- a/backends/sqs/backend.go
+++ b/backends/sqs/backend.go
@@ -202,7 +202,7 @@ func (s *Backend) ListQueues(in *rpc.ListQueuesRequest, stream rpc.QProxy_ListQu
 
 		if queueId, err := QueueUrlToQueueId(*url); err != nil {
 			log.Printf("Got error while converting queue url: %v", err)
-			s.m.APIErrors.WithLabelValues("ListQueues", in.Namespace, "").Inc()
+			s.m.APIErrors.WithLabelValues("ListQueues", in.Namespace, *url, "Malformed queue name").Inc()
 			// skip queue with malformed name
 			continue
 		} else if strings.Contains(queueId.Name, in.Filter) {


### PR DESCRIPTION
```
panic: inconsistent label cardinality: expected 4 label values but got 3 in []string{"ListQueues", "prod", ""}
goroutine 7 [running]:
github.com/wish/qproxy/vendor/github.com/prometheus/client_golang/prometheus.
```